### PR TITLE
fix: network entry timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ Stop the stream:
 ```js
 stream.destroy()
 ```
+
+## Timings
+
+You can control the network entry timings using the `entry.timings` API. It provides you with the methods you have to call _sequentially_ to indicate various staged of the request.
+
+**The order of the timing metrics:**
+
+1. `socketOpened`, socket opened but not connected yet.
+1. `dnsLookupEnd`, socket has resolved the DNS name.
+1. `connected`, socket has connected.
+1. `connectedSecure` (_Optional_)
+1. `requestEnd`, request is finished (request headers and body sent).
+1. `responseStart`, first byte of the response received.
+1. `responseEnd`, last byte of the response received.
+
+Entry timings are _dependent_, so if the previous timing is missing, the next one will not be calculated. For example, if `entry.timings.dnsLookupEnd()` was never called, the network entry will have both `dns` and `connected` timings as `-1`.

--- a/src/EntryTimings.ts
+++ b/src/EntryTimings.ts
@@ -32,6 +32,7 @@ export class EntryTimings implements Har.Timings {
   receive: number = 0
 
   private _requestStart: number = Date.now()
+  private _socket: number = 0
   private _dnsLookupEnd: number = 0
   private _connected: number = 0
   private _connectedSecure: number = 0
@@ -55,21 +56,28 @@ export class EntryTimings implements Har.Timings {
     )
   }
 
+  public socketOpened() {
+    this._socket = Date.now()
+  }
+
   public dnsLookupEnd() {
     this._dnsLookupEnd = Date.now()
+
+    if (this._socket) {
+      this.dns = this._dnsLookupEnd - this._socket
+    }
   }
 
   public connected() {
     this._connected = Date.now()
-    this.blocked = Math.max(0.01, this._requestStart - this._connected)
-    this.dns = this._connected - this._dnsLookupEnd
-    this.connect = this._connected - this._dnsLookupEnd
+    this.blocked = Math.max(0.01, this._socket - this._requestStart)
+    this.connect =
+      (this._connectedSecure || this._connected) - this._dnsLookupEnd
   }
 
   public secureConnected() {
     this._connectedSecure = Date.now()
     this.ssl = this._connectedSecure - this._connected
-    this.connect = this._connectedSecure - this._dnsLookupEnd
   }
 
   public requestEnd() {
@@ -84,7 +92,7 @@ export class EntryTimings implements Har.Timings {
 
   public responseEnd() {
     this._responseEnd = Date.now()
-    this.receive = this._responseEnd - this._requestEnd
+    this.receive = this._responseEnd - this._responseFirstByte
   }
 
   public toJSON(): Har.Timings {

--- a/src/EntryTimings.ts
+++ b/src/EntryTimings.ts
@@ -70,29 +70,47 @@ export class EntryTimings implements Har.Timings {
 
   public connected() {
     this._connected = Date.now()
-    this.blocked = Math.max(0.01, this._socket - this._requestStart)
-    this.connect =
-      (this._connectedSecure || this._connected) - this._dnsLookupEnd
+
+    if (this._requestStart) {
+      this.blocked = Math.max(0.01, this._socket - this._requestStart)
+    }
+
+    if (this._dnsLookupEnd) {
+      this.connect =
+        (this._connectedSecure || this._connected) - this._dnsLookupEnd
+    }
   }
 
   public secureConnected() {
     this._connectedSecure = Date.now()
-    this.ssl = this._connectedSecure - this._connected
+
+    if (this._connected) {
+      this.ssl = this._connectedSecure - this._connected
+    }
   }
 
   public requestEnd() {
     this._requestEnd = Date.now()
-    this.send = this._requestEnd - (this._connectedSecure || this._connected)
+
+    if (this._connectedSecure || this._connected) {
+      this.send = this._requestEnd - (this._connectedSecure || this._connected)
+    }
   }
 
   public responseStart() {
     this._responseFirstByte = Date.now()
-    this.wait = this._responseFirstByte - this._requestEnd
+
+    if (this._requestEnd) {
+      this.wait = this._responseFirstByte - this._requestEnd
+    }
   }
 
   public responseEnd() {
     this._responseEnd = Date.now()
-    this.receive = this._responseEnd - this._responseFirstByte
+
+    if (this._responseFirstByte) {
+      this.receive = this._responseEnd - this._responseFirstByte
+    }
   }
 
   public toJSON(): Har.Timings {

--- a/test/HarTiming.test.ts
+++ b/test/HarTiming.test.ts
@@ -12,6 +12,8 @@ afterAll(() => {
 it('calculates the timings for insecure request', () => {
   const timings = new EntryTimings()
 
+  timings.socketOpened()
+  vi.advanceTimersByTime(5)
   timings.dnsLookupEnd()
   vi.advanceTimersByTime(10)
   timings.connected()
@@ -27,18 +29,20 @@ it('calculates the timings for insecure request', () => {
 
   expect(timings.toJSON()).toEqual<Har.Timings>({
     blocked: 0.01,
-    dns: 10,
+    dns: 5,
     connect: 10,
     ssl: -1,
     send: 20,
     wait: 30,
-    receive: 70,
+    receive: 40,
   })
 })
 
 it('calculates the rimgins for secure (SSL) request', () => {
   const timings = new EntryTimings()
 
+  timings.socketOpened()
+  vi.advanceTimersByTime(5)
   timings.dnsLookupEnd()
   vi.advanceTimersByTime(10)
   timings.connected()
@@ -57,11 +61,11 @@ it('calculates the rimgins for secure (SSL) request', () => {
 
   expect(timings.toJSON()).toEqual<Har.Timings>({
     blocked: 0.01,
-    dns: 10,
-    connect: 15,
+    dns: 5,
+    connect: 10,
     ssl: 5,
     send: 20,
     wait: 30,
-    receive: 70,
+    receive: 40,
   })
 })


### PR DESCRIPTION
## Changes

- Adds a new internal `_socket` timing that indicates when the socket was created (not connected yet). This is crucial for correct `dns` and `connection` timings calculations.
- Adjusts a few timings that were incorrectly calculated.
- Adds docs on the timing methods and their order. 
- Does not set dependent timings if their dependencies were not set (e.g. if `dnsLookupEnd` was not called, both `dns` and `connected` timings will be skipped).